### PR TITLE
Chore(docker): Switch to named volumes for persistent storage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - ETCD_QUOTA_BACKEND_BYTES=4294967296
       - ETCD_SNAPSHOT_COUNT=50000
     volumes:
-      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/etcd:/etcd
+      - etcd_data:/etcd
     command: etcd -advertise-client-urls=http://127.0.0.1:2379 -listen-client-urls http://0.0.0.0:2379 --data-dir /etcd
     healthcheck:
       test: ["CMD", "etcdctl", "endpoint", "health"]
@@ -28,7 +28,7 @@ services:
       - "9001:9001"
       - "9000:9000"
     volumes:
-      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/minio:/minio_data
+      - minio_data:/minio_data
     command: minio server /minio_data --console-address ":9001"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
@@ -41,13 +41,13 @@ services:
     image: milvusdb/milvus:v2.5.6
     command: ["milvus", "run", "standalone"]
     security_opt:
-    - seccomp:unconfined
+      - seccomp:unconfined
     environment:
       ETCD_ENDPOINTS: etcd:2379
       MINIO_ADDRESS: minio:9000
-      MILVUS_LISTEN_ADDRESS: "0.0.0.0"  # <--- Ensure Milvus listens on all IPs
+      MILVUS_LISTEN_ADDRESS: "0.0.0.0"
     volumes:
-      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/milvus:/var/lib/milvus
+      - milvus_data:/var/lib/milvus
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9091/healthz"]
       interval: 30s
@@ -60,6 +60,11 @@ services:
     depends_on:
       - "etcd"
       - "minio"
+
+volumes:
+  etcd_data:
+  minio_data:
+  milvus_data:
 
 networks:
   default:


### PR DESCRIPTION
### What this PR does
This PR updates the docker-compose.yml file to replace bind mounts with Docker-managed named volumes for the following services:
- etcd
- minio
- milvus-standalone

### Why this change is needed
Improved data persistence: Named volumes are managed by Docker and are less prone to accidental data loss compared to bind mounts.
- Simplifies setup: No need to create and manage host directories manually.
- Environment consistency: Avoids issues with relative paths or OS-specific behavior when using bind mounts.
- Easier backups and migration using Docker volume commands.